### PR TITLE
K8s power managememt

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
   "azureFunctions.preDeployTask": "publish",
   "cSpell.words": [
       "Serilog"
-  ]
+  ],
+  "dotnet-test-explorer.testProjectPath": "tests"
 }

--- a/build/function-pipeline.yml
+++ b/build/function-pipeline.yml
@@ -38,10 +38,11 @@ stages:
 
           # Install Report Generator tool
           - task: DotNetCoreCLI@2
-            displayName: Restore Packages
+            displayName: Install ReportGenerator Tool
             inputs:
-              command: restore
-              projects: '$(Build.SourcesDirectory)/tests/*.csproj'
+              command: custom
+              custom: tool
+              arguments: install dotnet-reportgenerator-globaltool -g
 
           # Generate a report for the code coverga
           - task: DotNetCoreCLI@2

--- a/build/function-pipeline.yml
+++ b/build/function-pipeline.yml
@@ -36,12 +36,19 @@ stages:
               arguments: --logger "trx;LogFileName=testresults.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=TestResults/Coverage/
               projects: '$(Build.SourcesDirectory)/tests/*.csproj'
 
+          # Install Report Generator tool
+          - task: DotNetCoreCLI@2
+            displayName: Restore Packages
+            inputs:
+              command: restore
+              projects: '$(Build.SourcesDirectory)/tests/*.csproj'
+
           # Generate a report for the code coverga
           - task: DotNetCoreCLI@2
             displayName: Generate Coverage Report
             inputs:
               command: custom
-              custom: reportgenerator
+              custom: reportgenerator 
               arguments: -reports:TestResults/Coverage/coverage.cobertura.xml -targetDir:TestResults/Coverage/Reports -tag:$(Build.BuildNumber) -reportTypes:inlinehtml 
 
           # Publish test and code coverage results

--- a/build/function-pipeline.yml
+++ b/build/function-pipeline.yml
@@ -51,7 +51,7 @@ stages:
           # Generate a report for the code coverage
           - script: reportgenerator -reports:$(Build.SourcesDirectory)/TestResults/Coverage/coverage.cobertura.xml -targetDir:$(Build.SourcesDirectory)/TestResults/Coverage/Reports -tag:$(Build.BuildNumber) -reportTypes:htmlInline
             displayName: Generate Coverage Report
-            
+
           # Publish code coverage results
           - task: PublishCodeCoverageResults@1
             inputs:
@@ -126,12 +126,13 @@ stages:
 
   - stage: release_build_artefacts
     displayName: Create GitHub release
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     dependsOn: build_reaper_function
 
     jobs:
       
       - job: release
-        displayName: Uplaod Artefacts
+        displayName: Upload Artefacts
         pool:
           vmImage: $(buildImage)
 

--- a/build/function-pipeline.yml
+++ b/build/function-pipeline.yml
@@ -48,7 +48,10 @@ stages:
               arguments: --logger "trx;LogFileName=testresults.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=TestResults/Coverage/
               projects: '$(Build.SourcesDirectory)/tests/*.csproj'
 
-          # Generate a report for the code coverga
+          # Generate a report for the code coverage
+          - script: reportgenerator -reports:TestResults/Coverage/coverage.cobertura.xml -targetDir:TestResults/Coverage/Reports -tag:$(Build.BuildNumber) -reportTypes:inlinehtml 
+            displayName: Generate Coverage Report
+
           - task: DotNetCoreCLI@2
             displayName: Generate Coverage Report
             inputs:

--- a/build/function-pipeline.yml
+++ b/build/function-pipeline.yml
@@ -28,14 +28,6 @@ stages:
 
         steps:
 
-          # Run the tests
-          - task: DotNetCoreCLI@2
-            displayName: Execute Unit Tests
-            inputs:
-              command: test
-              arguments: --logger "trx;LogFileName=testresults.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=TestResults/Coverage/
-              projects: '$(Build.SourcesDirectory)/tests/*.csproj'
-
           # Install Report Generator tool
           - task: DotNetCoreCLI@2
             displayName: Install ReportGenerator Tool
@@ -43,6 +35,18 @@ stages:
               command: custom
               custom: tool
               arguments: install dotnet-reportgenerator-globaltool -g
+
+          # Add the dotnet tools dir to the path
+          - script: echo "##vso[task.prependpath]$HOME/.dotnet/tools"
+            displayName: Add DotNet custom tools to the path
+
+          # Run the tests
+          - task: DotNetCoreCLI@2
+            displayName: Execute Unit Tests
+            inputs:
+              command: test
+              arguments: --logger "trx;LogFileName=testresults.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=TestResults/Coverage/
+              projects: '$(Build.SourcesDirectory)/tests/*.csproj'
 
           # Generate a report for the code coverga
           - task: DotNetCoreCLI@2

--- a/build/function-pipeline.yml
+++ b/build/function-pipeline.yml
@@ -45,32 +45,19 @@ stages:
             displayName: Execute Unit Tests
             inputs:
               command: test
-              arguments: --logger "trx;LogFileName=testresults.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=TestResults/Coverage/
+              arguments: --logger "trx;LogFileName=testresults.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/
               projects: '$(Build.SourcesDirectory)/tests/*.csproj'
 
           # Generate a report for the code coverage
-          - script: reportgenerator -reports:TestResults/Coverage/coverage.cobertura.xml -targetDir:TestResults/Coverage/Reports -tag:$(Build.BuildNumber) -reportTypes:inlinehtml 
+          - script: reportgenerator -reports:$(Build.SourcesDirectory)/TestResults/Coverage/coverage.cobertura.xml -targetDir:$(Build.SourcesDirectory)/TestResults/Coverage/Reports -tag:$(Build.BuildNumber) -reportTypes:htmlInline
             displayName: Generate Coverage Report
-
-          - task: DotNetCoreCLI@2
-            displayName: Generate Coverage Report
-            inputs:
-              command: custom
-              custom: reportgenerator 
-              arguments: -reports:TestResults/Coverage/coverage.cobertura.xml -targetDir:TestResults/Coverage/Reports -tag:$(Build.BuildNumber) -reportTypes:inlinehtml 
-
-          # Publish test and code coverage results
-          - task: PublishTestResults@2
-            inputs:
-              testRunner: VSTest
-              testResultsFiles: '**/TestResults/*.trx'
-              failTaskOnFailedTests: true
-
+            
+          # Publish code coverage results
           - task: PublishCodeCoverageResults@1
             inputs:
               codeCoverageTool: 'cobertura'
-              summaryFileLocation: $(Build.SourcesDirectory)/tests/TestResults/Coverage/**/coverage.cobertura.xml
-              reportDirectory: $(Build.SourcesDirectory)/tests/TestResults/Coverage/Reports
+              summaryFileLocation: $(Build.SourcesDirectory)/TestResults/Coverage/**/coverage.cobertura.xml
+              reportDirectory: $(Build.SourcesDirectory)/TestResults/Coverage/Reports
               failIfCoverageEmpty: false 
 
           # Compile the function and output to a directory

--- a/build/function-pipeline.yml
+++ b/build/function-pipeline.yml
@@ -28,6 +28,27 @@ stages:
 
         steps:
 
+          # Build the tests solution
+          - task: DotNetCoreCLI@2
+            displayName: Compile Unit Tests
+            inputs:
+              projects: '$(Build.SourcesDirectory)/tests/*.csproj'
+
+          # Run unit tests
+          - task: VSTest@2
+            displayName: Run Unit Tests
+            inputs: 
+              testAssemblyVer2: |
+                $(Build.SourcesDirectory)/tests/**/*Tests*.dll
+                !$(Build.SourcesDirectory)/tests/**/*Models*.dll
+                !**\*TestAdapter.dll
+                !**\obj\**
+                !**\$(BuildConfiguration)\**\*IntegrationTests*.dll
+              codeCoverageEnabled: true
+              testRunTitle: '$(Build.DefinitionName) | $(Build.Reason) |$(Build.SourceVersion)'
+              platform: '$(buildPlatform)'
+              configuration: '$(buildConfiguration)'
+
           # Compile the function and output to a directory
           - task: DotNetCoreCLI@2
             displayName: Compile function

--- a/build/function-pipeline.yml
+++ b/build/function-pipeline.yml
@@ -28,26 +28,35 @@ stages:
 
         steps:
 
-          # Build the tests solution
+          # Run the tests
           - task: DotNetCoreCLI@2
-            displayName: Compile Unit Tests
+            displayName: Execute Unit Tests
             inputs:
+              command: test
+              arguments: --logger "trx;LogFileName=testresults.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=TestResults/Coverage/
               projects: '$(Build.SourcesDirectory)/tests/*.csproj'
 
-          # Run unit tests
-          - task: VSTest@2
-            displayName: Run Unit Tests
-            inputs: 
-              testAssemblyVer2: |
-                $(Build.SourcesDirectory)/tests/**/*Tests*.dll
-                !$(Build.SourcesDirectory)/tests/**/*Models*.dll
-                !**\*TestAdapter.dll
-                !**\obj\**
-                !**\$(BuildConfiguration)\**\*IntegrationTests*.dll
-              codeCoverageEnabled: true
-              testRunTitle: '$(Build.DefinitionName) | $(Build.Reason) |$(Build.SourceVersion)'
-              platform: '$(buildPlatform)'
-              configuration: '$(buildConfiguration)'
+          # Generate a report for the code coverga
+          - task: DotNetCoreCLI@2
+            displayName: Generate Coverage Report
+            inputs:
+              command: custom
+              custom: reportgenerator
+              arguments: -reports:TestResults/Coverage/coverage.cobertura.xml -targetDir:TestResults/Coverage/Reports -tag:$(Build.BuildNumber) -reportTypes:inlinehtml 
+
+          # Publish test and code coverage results
+          - task: PublishTestResults@2
+            inputs:
+              testRunner: VSTest
+              testResultsFiles: '**/TestResults/*.trx'
+              failTaskOnFailedTests: true
+
+          - task: PublishCodeCoverageResults@1
+            inputs:
+              codeCoverageTool: 'cobertura'
+              summaryFileLocation: $(Build.SourcesDirectory)/tests/TestResults/Coverage/**/coverage.cobertura.xml
+              reportDirectory: $(Build.SourcesDirectory)/tests/TestResults/Coverage/Reports
+              failIfCoverageEmpty: false 
 
           # Compile the function and output to a directory
           - task: DotNetCoreCLI@2

--- a/docs_site/content/_index.md
+++ b/docs_site/content/_index.md
@@ -8,6 +8,10 @@ Azure Reaper is a way of reducing costs in Azure subscriptions as well as automa
 
 Azure is a great place to play around with new things and test deployments of code on infrastructure, however more often than not these resources are not deleted so they incur an ongoing cost, such as a virtual machines and Kubernetes nodes.
 
+{{% notice note %}}
+The Azure Reaper can only manage AKS clusters that are using Scale Sets. The ability to shutdown an AKS cluster is not available to those clusters running as an Availability Set.
+{{% /notice %}}
+
 Reaper helps to keep down costs by:
 
  - Shutting down machines when they are not being used, and starting them up again
@@ -35,7 +39,7 @@ This helps to identify who has owns the group and allows the Reaper to determine
 
 Every 10 minutes, by default, the reaper runs to determine which resources need to be shutdown or deleted.
 
-The Reaper function can also be triggered manually nby using the API.
+The Reaper function can also be triggered manually by using the API.
 {{% /column %}}
 {{% column class="border-purple" %}}
 ## API

--- a/function/Lib/Models/PowerStatistics.cs
+++ b/function/Lib/Models/PowerStatistics.cs
@@ -1,0 +1,86 @@
+
+using System.Collections.Generic;
+
+namespace Azure.Reaper.Lib.Models
+{
+    public class PowerStatistics
+    {
+
+        private List<string> vms_started;
+        private List<string> vms_stopped;
+        private List<string> aks_started;
+        private List<string> aks_stopped;
+
+        public PowerStatistics() {
+            vms_started = new List<string>();
+            vms_stopped = new List<string>();
+            aks_started = new List<string>();
+            aks_stopped = new List<string>();
+        }
+
+        // create methods to add the items to the lists
+        public void StartResource(string type, string name)
+        {
+            switch (type)
+            {
+                case "vm":
+                    vms_started.Add(name);
+                    break;
+
+                case "aks":
+                    aks_started.Add(name);
+                    break;
+            }
+        }
+
+        public void StopResource(string type, string name)
+        {
+            switch (type)
+            {
+                case "vm":
+                    vms_stopped.Add(name);
+                    break;
+
+                case "aks":
+                    aks_stopped.Add(name);
+                    break;
+            }
+        }
+
+        public List<string> GetStarted(string type)
+        {
+            List<string> list = new List<string>();
+
+            switch (type)
+            {
+                case "vm":
+                    list = vms_started;
+                    break;
+
+                case "aks":
+                    list = aks_started;
+                    break;
+            }
+
+            return list;
+        } 
+
+        public List<string> GetStopped(string type)
+        {
+            List<string> list = new List<string>();
+
+            switch (type)
+            {
+                case "vm":
+                    list = vms_stopped;
+                    break;
+
+                case "aks":
+                    list = aks_stopped;
+                    break;
+            }
+
+            return list;
+        }         
+    }
+}

--- a/function/Lib/PowerSchedule.cs
+++ b/function/Lib/PowerSchedule.cs
@@ -1,0 +1,318 @@
+using Azure.Reaper.Lib.Interfaces;
+using Azure.Reaper.Lib.Models;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Linq;
+
+namespace Azure.Reaper.Lib
+{
+    public class PowerSchedule
+    {
+
+        // List of tags from the resource and resource group merged together
+        public Dictionary<string, string> Tags;
+
+        // The powerstate of the resource
+        private string _powerState;
+
+        // The region that the resource is running in
+        private string _regionName;
+
+        // List of settings
+        private IEnumerable<Setting> _settings;
+        private IEnumerable<LocationTZ> _timeZones;
+
+        // States whether the resource should be started or not
+        private bool startResource = false;
+        private bool stopResource = false;
+
+        // State the start and stop times of the resource
+        public TimeSpan tsStart;
+        public TimeSpan tsStop;
+        public bool PermittedToRunOnDay = false;
+
+        // Logger object
+        private ILog _logger;
+
+        public TimeZoneInfo zoneInfo = TimeZoneInfo.Utc;
+
+        // Define the regular expression pattern which will be used to determine the
+        // start and stop time from the tag value
+        private Regex pattern = new Regex(@"((?:[01]\d|2[0-3]):?(?:[0-5]\d))\s*?-\s*?((?:[01]\d|2[0-3]):?(?:[0-5]\d))");
+
+        private DateTime _timeNowUTC;
+        private DateTime _timzoneNow;
+
+        /// <summary>
+        /// PowerSchedule is used to determine if the specified resource should be running or not
+        /// The constructor takes the tags of the resource group and the resource itself
+        /// </summary>
+        /// <param name="rgTags">Tags on the resource group</param>
+        /// <param name="resTags">Tags on the resource</param>
+        /// <param name="powerState">Current powerstate of the resource</param>
+        public PowerSchedule(
+            List<Setting> settings,
+            IEnumerable<LocationTZ> timeZones,
+            ILog logger,
+            DateTime timeNowUTC,
+            IReadOnlyDictionary<string, string> rgTags,
+            IReadOnlyDictionary<string, string> resTags,
+            string powerState,
+            string regionName)
+        {
+            // merge the tags of the group and the resource
+            // the resource tags need to overwrite those from the group as they
+            // have higher priority
+            Tags = (Dictionary<string, string>) rgTags;
+
+            MergeTags(rgTags, resTags);
+            _powerState = powerState.ToLower();
+            _regionName = regionName;
+            _settings = settings;
+            _timeZones = timeZones;
+            _logger = logger;
+            _timeNowUTC = timeNowUTC;
+
+            // using the settings, set the start and stop timespans
+            // to be use in future calculations
+            string startTime = settings.First(s => s.name == "vm_start").value;
+            string stopTime = settings.First(s => s.name == "vm_stop").value;
+
+            tsStart = DateTime.ParseExact(startTime, "HHmm", CultureInfo.InvariantCulture).TimeOfDay;
+            tsStop = DateTime.ParseExact(stopTime, "HHmm", CultureInfo.InvariantCulture).TimeOfDay;
+        }
+
+        public void MergeTags(
+            IReadOnlyDictionary<string, string> rgTags,
+            IReadOnlyDictionary<string, string> resTags
+        )
+        {
+            Tags = (Dictionary<string, string>) rgTags;
+
+            // iterate over the resTags and add them, or overwrite the tags
+            foreach (KeyValuePair<string, string> item in resTags)
+            {
+                Tags[item.Key] = item.Value;
+            }            
+        }
+
+        /// <summary>
+        /// States if the resource should be started or not
+        /// </summary>
+        /// <returns></returns>
+        public bool StartResource()
+        {
+            return startResource;
+        }
+
+        /// <summary>
+        /// States if the resource should be stopped or not
+        /// </summary>
+        /// <returns></returns>
+        public bool StopResource()
+        {
+            return stopResource;
+        }        
+
+        public void Process()
+        {
+
+            // Get the schedule from the tags
+            ScheduleFromTags();
+
+            // Determine the timezone
+            SetTimeZone();
+
+            // Determine if the machine should be running on this day or not
+            PermittedToRunDay();
+
+            ShouldBeRunning();
+
+        }
+
+        public void ShouldBeRunning()
+        {
+            bool shouldBeRunning = false;
+
+            // using the timespans and the permitted to run result, determine if the
+            // machine should be running or not
+            if ((_timzoneNow.TimeOfDay > tsStart &&
+                 _timzoneNow.TimeOfDay < tsStop &&
+                 PermittedToRunOnDay))
+            {
+                shouldBeRunning = true;
+            }
+
+            // determine if the resource should be started or stopped
+            // using the powerstate that has been supplied to the class
+            Regex regexStopped = new Regex("(?:powerstate/)?deallocated");
+            if (regexStopped.IsMatch(_powerState) && shouldBeRunning) {
+                startResource = true;
+            }
+
+            Regex regexRunning = new Regex("(?:powerstate/)?running");
+            if (regexRunning.IsMatch(_powerState) && !shouldBeRunning) {
+                stopResource = true;
+            }
+
+        }
+
+        /// <summary>
+        /// Determine if the resource has the tag set on it
+        /// </summary>
+        /// <param name="settingName">Name of the setting that contains the name of the tag</param>
+        /// <returns></returns>
+        public bool HasTag(string settingName)
+        {
+            bool result = false;
+
+            // get the name of the tag from the settings
+            string tagName = _settings.First(s => s.name == settingName).value;
+
+            // determine if the Tags contains the tagName
+            if (Tags.ContainsKey(tagName))
+            {
+                result = true;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Get the value from the tag that has been set if it exists
+        /// </summary>
+        /// <param name="settingName">Name of the setting that hold the name of the tag</param>
+        /// <returns></returns>
+        public string GetTag(string settingName)
+        {
+            string result = string.Empty;
+
+            if (HasTag(settingName))
+            {
+                // get the name of the tag from the settings
+                string tagName = _settings.First(s => s.name == settingName).value;
+                result = Tags[tagName];
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Determine if there is a tag set that states the schedule that should be used for the machines
+        /// </summary>
+        public void ScheduleFromTags()
+        {
+            // initialise method with some properties
+            bool result = false;
+            string settingName = "tag_vm_start_stop_time";
+
+            // determine if the tag has been set
+            result = HasTag(settingName);
+
+            // if the tag has been found then extract the necessary information
+            if (result)
+            {
+                // get the value of the tag
+                string schedule = GetTag(settingName);
+
+                // Ensure that the string matches the regular expression
+                // If it does then get the schedule from the tag
+                if (pattern.IsMatch(schedule))
+                {
+                    // create the message to be used in the log
+                    string message = String.Format(
+                        "Power state schedule found: {0}",
+                        schedule
+                    );
+
+                    _logger.Information(message);
+
+                    // Split the schedule string into the start and stop times
+                    // and then trim the string to make the necessary times
+                    string[] parts = schedule.Split("-").ToArray();
+                    tsStart = DateTime.ParseExact(parts[0].Trim().Replace(":", ""), "HHmm", CultureInfo.InvariantCulture).TimeOfDay;
+                    tsStop = DateTime.ParseExact(parts[1].Trim().Replace(":", ""), "HHmm", CultureInfo.InvariantCulture).TimeOfDay;
+                }
+                else
+                {
+                    _logger.Error("Power state schedule has an invalid format: ", schedule);
+                }
+            }
+
+        }
+
+        /// <summary>
+        /// Set the timezone that the schedule should work in from the region of the resource
+        /// or the tag (if one has been set)
+        /// </summary>
+        public void SetTimeZone()
+        {
+            // get the id of the zone
+            string zoneId = String.Empty;
+
+            // determine if the resource has a timezone tag set on it
+            string tagZone = GetTag("tag_timezone");
+
+            // if the tagZone is not empty, get the zone from that
+            // otherwise use the resource region to get the zone
+            if (!string.IsNullOrEmpty(tagZone))
+            {
+                zoneId = tagZone;
+            }
+            else
+            {
+                // Find the TimeZoneInfo based on the regionName
+                LocationTZ resourceZone = _timeZones.First(t => t.name == _regionName);
+                zoneId = resourceZone.tzId;
+            }
+
+            zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+
+            // work out the offset to be used for calculating times, based on the 
+            // specified timezone of the resource
+            _timzoneNow = TimeZoneInfo.ConvertTimeFromUtc(_timeNowUTC, zoneInfo);
+        }
+
+        /// <summary>
+        /// Determine if the resource should be running on the specified day
+        /// in the timezone of the resource
+        /// </summary>
+        /// <param name="timenow">The time now, in the timezone of the resource</param>
+        public void PermittedToRunDay()
+        {
+            // get the permitted days from settings
+            string days = _settings.First(s => s.name == "permitted_days").value;
+
+            // Attempt to get the tag that specifies the days of the week from 
+            // the resource
+            if (HasTag("tag_days_of_week"))
+            {
+                days = GetTag("tag_days_of_week");
+                _logger.Information("Resource contains permitted days for operation: {0}", days);
+            }
+
+            // Turn the permitted days into an array so that the current day can be searched for
+            string[] permittedDays = days.Split(",").ToArray();
+
+            // get the current day from the timenow
+            int currentDay = (int) _timzoneNow.DayOfWeek;
+
+            // if the current days is in the list then allow the macine to run
+            if (permittedDays.Contains(currentDay.ToString()))
+            {
+                PermittedToRunOnDay = true;
+            }
+            else
+            {
+                _logger.Information("Resource is not permitted to run on a {0}", _timzoneNow.DayOfWeek);
+            }
+
+        }
+
+
+
+    }
+}

--- a/function/Lib/PowerSchedule.cs
+++ b/function/Lib/PowerSchedule.cs
@@ -269,7 +269,8 @@ namespace Azure.Reaper.Lib
                 zoneId = resourceZone.tzId;
             }
 
-            zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+            // zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+            zoneInfo = TimeZoneConverter.TZConvert.GetTimeZoneInfo(zoneId);
 
             // work out the offset to be used for calculating times, based on the 
             // specified timezone of the resource

--- a/function/Lib/Process/Timer.cs
+++ b/function/Lib/Process/Timer.cs
@@ -81,8 +81,8 @@ namespace Azure.Reaper.Lib.Process
             NotificationDelay notificationDelay = new NotificationDelay(_backend, _logger);
 
             // Create an instance of the reaper and process it
-            Reaper reaper = new Reaper(_backend, _logger, notificationDelay);
-            reaper.Process(settings, subscriptions, locationTZ);
+            Reaper reaper = new Reaper(_backend, _logger, settings, notificationDelay);
+            reaper.Process(subscriptions, locationTZ);
         }
     }
 }

--- a/function/Lib/Reaper.cs
+++ b/function/Lib/Reaper.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Management.Compute.Fluent;
 using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ContainerService.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using Microsoft.Extensions.Logging;
 using System;
@@ -15,6 +16,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Azure.Reaper.Lib
 {
@@ -24,15 +26,21 @@ namespace Azure.Reaper.Lib
         private ILog _logger;
         private NotificationDelay _notificationDelay;
         private IBackend _backend;
+        private IAzure azure;
+        private List<Models.Setting> settings;
+        private IEnumerable<LocationTZ> timezones;
+        private DateTime timeNowUtc;
+        private Models.PowerStatistics powerStats;
 
-        public Reaper(IBackend backend, ILog logger, NotificationDelay notificationDelay)
+        public Reaper(IBackend backend, ILog logger, List<Models.Setting> settings, NotificationDelay notificationDelay)
         {
             _backend = backend;
             _logger = logger;
             _notificationDelay = notificationDelay;
+            this.settings = settings;
         }
 
-        public bool Process(List<Models.Setting> settings, List<Models.Subscription> subscriptions, Models.LocationTZ locationTZ)
+        public bool Process(List<Models.Subscription> subscriptions, Models.LocationTZ locationTZ)
         {
 
             // bool error = false;
@@ -48,7 +56,7 @@ namespace Azure.Reaper.Lib
             bool manage_vms = Convert.ToBoolean(settings.First(s => s.name == "manage_vms").value);
 
             // get a list of the timezones to work with
-            IEnumerable<LocationTZ> timezones = locationTZ.GetByName().GetData();
+            timezones = locationTZ.GetByName().GetData();
 
             // Create a connection to Slack
             // ensure that the webhook url can be turned into a URI
@@ -86,7 +94,7 @@ namespace Azure.Reaper.Lib
                 // IEnumerable<LocationTZ> timezones = timezone.GetAll();
 
                 // Define timestamp to work against so it is the same time for all checks
-                DateTime timeNowUtc = DateTime.UtcNow;
+                // DateTime timeNowUtc = DateTime.UtcNow;
 
                 // Create a NotificationDelay object to use to
                 // get previous notification alerts and add new ones
@@ -97,27 +105,20 @@ namespace Azure.Reaper.Lib
                 {
 
                     // only proceed if the reaper has been enabled on the subscription
+                    /*
                     if (!sub.reaper) {
                         _logger.Information("Reaper is not enabled on subscription: {name} [{id}]", sub.name, sub.subscription_id);
                         continue;
                     }
+                    */
 
                     // Determine the timenow to be used as criteria
                     // This is done on each subscription because there might be a lot of groups to enumerate
-                    DateTime _time_now = DateTime.UtcNow;
-                    string time_now = _time_now.ToString("yyyy-MM-ddTHH:mm:ssZ");
+                    timeNowUtc = DateTime.UtcNow;
+                    string time_now = timeNowUtc.ToString("yyyy-MM-ddTHH:mm:ssZ");
 
                     // Login to Azure with the credentials for this subscription
-                    IAzure azure = Utilities.AzureLogin(sub, AzureEnvironment.AzureGlobalCloud, _logger);
-
-                    // AzureCredentials credentials = new AzureCredentials(
-                    //     new ServicePrincipalLoginInformation
-                    //     {
-                    //         ClientId = sub.client_id,
-                    //         ClientSecret = sub.client_secret
-                    //     }, sub.tenant_id, AzureEnvironment.AzureGlobalCloud
-                    // );
-                    // Microsoft.Azure.Management.Fluent.Azure azure = Microsoft.Azure.Management.Fluent.Azure.Configure().Authenticate(credentials).WithSubscription(sub.subscription_id);
+                    azure = Utilities.AzureLogin(sub, AzureEnvironment.AzureGlobalCloud, _logger);
 
                     // get a list of resource groups in the subscription
                     IEnumerable<IResourceGroup> resource_groups = azure.ResourceGroups.List();
@@ -184,11 +185,15 @@ namespace Azure.Reaper.Lib
                         else
                         {
 
+                            // Initialise the powerstatistics to be used for notifications
+                            powerStats = new PowerStatistics();
+
                             // So that the Slack user is not inundated with messages, ensure that all machines that have been
                             // found to be in violation of running times are bundled up
-                            List<string> stopped = new List<string>();
-                            List<string> started = new List<string>();
+                            // List<string> stopped = new List<string>();
+                            // List<string> started = new List<string>();
 
+/*
                             // as the resource group is valid look at the virtual machines that are running
                             // and determine if they should be shutdown or not
                             IEnumerable<IVirtualMachine> vms = azure.VirtualMachines.ListByResourceGroup(resource_group.Name);
@@ -230,9 +235,14 @@ namespace Azure.Reaper.Lib
                                 nd.name = virtualMachine.GetName();
 
                                 await _notificationDelay.Upsert(nd);
-                                */
+                                
                                 
                             }
+                            */
+
+                            manageVirtualMachines(resource_group);
+
+                            manageK8sClusters(resource_group);
 
                             // only send out messages for VMs if there are some
                             //if (vms.Count() > 0 && (started.Count > 0 || stopped.Count > 0))
@@ -259,8 +269,150 @@ namespace Azure.Reaper.Lib
                     }
                 }
             // }
-
+ 
             return true;
+        }
+
+        /// <summary>
+        /// Find the Kubernetes clusters in the specified resource group and determine if they need to be
+        /// left alone, shutdown or startedup
+        /// </summary>
+        /// <param name="rgName">Name of hte resource group to look for clusters in</param>
+        private void manageK8sClusters(IResourceGroup rg) {
+
+            // determine if any kubernetes clusters exist in the group
+            IEnumerable<IKubernetesCluster> clusters = azure.KubernetesClusters.ListByResourceGroup(rg.Name);
+
+            if (clusters.Count() == 0) {
+                _logger.Information("No AKS clusters in group: {0}", rg.Name);
+            } else {
+
+                _logger.Information("Analysing AKS Clusters: {0}", clusters.Count().ToString());
+
+                // iterate around the clusters
+                foreach (IKubernetesCluster cluster in clusters) {
+
+                    string operation = String.Empty;
+                    string powerState = cluster.Inner.PowerState.Code.Value;
+
+                    // Determine if the cluster should be running or not
+                    PowerSchedule powerSchedule = new PowerSchedule(
+                        settings, 
+                        timezones, 
+                        _logger,
+                        timeNowUtc,
+                        rg.Tags, 
+                        cluster.Tags, 
+                        powerState, 
+                        cluster.RegionName
+                    );
+
+                    powerSchedule.Process();
+
+                    // use the powerschedule information to determine if the resource should be running
+                    if (powerSchedule.StartResource())
+                    {
+                        powerStats.StartResource("aks", cluster.Name);
+                        operation = "start";
+                    }
+
+                    if (powerSchedule.StopResource())
+                    {
+                        powerStats.StopResource("aks", cluster.Name);
+                        operation = "stop";
+                    }
+
+                    if (!String.IsNullOrEmpty(operation))
+                    {
+                        // build up the URL
+                        object[] replacements = { cluster.Manager.RestClient.BaseUri, cluster.Manager.SubscriptionId, rg.Name, cluster.Name, operation };
+                        string url = String.Format("{0}subscriptions/{1}/resourceGroups/{2}/providers/Microsoft.ContainerService/managedClusters/{3}/{4}?api-version=2021-05-01", replacements);
+
+                        _logger.Information(url);
+
+                        // Create a new HttpClient top 
+                        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url);
+                        CancellationToken cancellationToken = new CancellationToken();
+                        HttpClient httpClient = new HttpClient();
+
+                        cluster.Manager.RestClient.Credentials.ProcessHttpRequestAsync(request, cancellationToken).GetAwaiter().GetResult();
+                        HttpResponseMessage response = httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).GetAwaiter().GetResult();
+                        
+                        _logger.Information(response.Content.ReadAsStringAsync().Result);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Find the virtual machines in the group and determine what ones need to have
+        /// the powerstate modified
+        /// </summary>
+        /// <param name="rg"></param>
+        private void manageVirtualMachines(IResourceGroup rg) {
+
+            // get a list of the virtual machines in the group
+            IEnumerable<IVirtualMachine> virtualMachines = azure.VirtualMachines.ListByResourceGroup(rg.Name);
+
+            // check the beginning of the name of hte resource group
+            // if it starts with MC_ then it will be a managed cluster and Reaper should not deal
+            // with the virtual machines directly
+            if (rg.Name.ToLower().StartsWith("mc_"))
+            {
+                _logger.Information("Not managing Virtual Machines in managed AKS cluster: {0}", rg.Name);
+                return;
+            }
+
+            if (virtualMachines.Count() == 0)
+            {
+                _logger.Information("No Virtual Machines in group: {0}", rg.Name);
+                return;
+            }
+
+            _logger.Information("Analysing Virtual Machines: {0}", virtualMachines.Count().ToString());
+
+            // Determine if VMs are to be managed, return if they are not
+            bool manage_vms = Convert.ToBoolean(settings.First(s => s.name == "manage_vms").value);
+            if (!manage_vms) {
+                _logger.Information("Reaper is not set to manage virtual machines, please check your settings");
+                return;
+            }
+
+            foreach (IVirtualMachine vm in virtualMachines)
+            {
+                // get the powerstate of the vm
+                string powerstate = vm.PowerState.ToString();
+
+                // Create a powerschedule object to determine if the machine should be running or not
+                PowerSchedule powerSchedule = new PowerSchedule(
+                    settings,
+                    timezones,
+                    _logger,
+                    timeNowUtc,
+                    rg.Tags,
+                    vm.Tags,
+                    powerstate,
+                    vm.RegionName
+                );
+
+                powerSchedule.Process();
+
+                // start or stop the resource based on the results from the powerschedule
+                if (powerSchedule.StartResource())
+                {
+                    powerStats.StartResource("vm", vm.Name);
+                    _logger.Information("[{0}] Starting virtual machine: {1}", rg.Name, vm.Name);
+                    vm.StartAsync();
+                }
+
+                if (powerSchedule.StopResource())
+                {
+                    powerStats.StopResource("vm", vm.Name);
+                    _logger.Information("[{0}] Stopping virtual machine: {1}", rg.Name, vm.Name);
+                    vm.DeallocateAsync();
+                }
+
+            }
         }
     }
 }

--- a/function/Lib/Resources/Group.cs
+++ b/function/Lib/Resources/Group.cs
@@ -101,7 +101,7 @@ namespace Azure.Reaper.Lib.Resources
 
         if (inUse)
         {
-          _logger.Information("Group is in use, ignoring: {group}", resourceGroup.Name);
+          _logger.Information("Group is in use, will not delete: {group}", resourceGroup.Name);
           result = true;
         }
 

--- a/function/azure-reaper.csproj
+++ b/function/azure-reaper.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Serilog" Version="2.10.1-dev-01285" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0-dev-00839" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.2-dev-10284" />
+    <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/tests/AzureReaperTests.csproj
+++ b/tests/AzureReaperTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\function\azure-reaper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AzureReaperTests.csproj
+++ b/tests/AzureReaperTests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/AzureReaperTests.csproj
+++ b/tests/AzureReaperTests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
@@ -22,5 +26,10 @@
   <ItemGroup>
     <ProjectReference Include="..\function\azure-reaper.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.2.15" />
+  </ItemGroup>
+
 
 </Project>

--- a/tests/PowerScheduleTests.cs
+++ b/tests/PowerScheduleTests.cs
@@ -1,0 +1,317 @@
+using System;
+using Xunit;
+using System.Collections.Generic;
+using Azure.Reaper.Lib;
+
+namespace Tests
+{
+
+    public class PowerScheduleTests : IClassFixture<TestsFixture>
+    {
+        private const string POWER_STATE = "powerstate/running";
+        private const string REGION = "ukwest";
+        private const string TIMEZONE = "GMT Standard Time";
+        TestsFixture data;
+
+        public PowerScheduleTests(TestsFixture data)
+        {
+            this.data = data;
+        }
+
+        [Fact]
+        public void MergeTagsNoConflicts()
+        {
+
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            groupTags.Add("ownerEmail", "me@example.com");
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                DateTime.UtcNow,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            // Get the merged tags
+            Dictionary<string, string> tags = powerSchedule.Tags;
+
+            // assert that there is one item and it is the ownerEmail
+            Assert.Equal(1, tags.Count);
+            Assert.Contains("ownerEmail", tags.Keys);
+            Assert.Equal("me@example.com", tags["ownerEmail"]);
+        }
+
+        [Fact]
+        public void MergeTagsWithConflicts()
+        {
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            groupTags.Add("ownerEmail", "me@example.com");
+            resourceTags.Add("ownerEmail", "example@me.com");
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                DateTime.UtcNow,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            // Get the merged tags
+            Dictionary<string, string> tags = powerSchedule.Tags;
+
+            // assert that there is one item and it is the ownerEmail
+            Assert.Equal(1, tags.Count);
+            Assert.Contains("ownerEmail", tags.Keys);
+            Assert.Equal("example@me.com", tags["ownerEmail"]);            
+        }
+
+        [Fact]
+        public void HasAndGetTag()
+        {
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            groupTags.Add("STARTSTOPTIME", "09:00 - 2000");
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                DateTime.UtcNow,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            Assert.True(powerSchedule.HasTag("tag_vm_start_stop_time"));
+            Assert.Equal("09:00 - 2000", powerSchedule.GetTag("tag_vm_start_stop_time"));
+        }
+
+        [Fact]
+        public void GetSchedule()
+        {
+
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            groupTags.Add("STARTSTOPTIME", "09:00 - 2000");
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                DateTime.UtcNow,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            // get the schedule from the tags
+            powerSchedule.ScheduleFromTags();
+
+            // create the timespan to measure against
+            TimeSpan startTime = new TimeSpan(9, 0, 0);
+            TimeSpan stopTime = new TimeSpan(20, 0, 0);
+
+            // assert that the start and stop times are correct
+            Assert.Equal(startTime, powerSchedule.tsStart);
+            Assert.Equal(stopTime, powerSchedule.tsStop);
+        }
+
+        [Fact]
+        /// <summary>
+        /// This will get set the timezone based on the region of the resource
+        /// </summary>
+        public void GetTimeZoneFromRegion() {
+            
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                DateTime.UtcNow,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            powerSchedule.SetTimeZone();
+
+            // ensure that the zoneInfo is correctly set
+            TimeZoneInfo zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(TIMEZONE);
+            Assert.Equal(zoneInfo, powerSchedule.zoneInfo);
+        }
+
+        [Fact]
+        /// <summary>
+        /// Test that the timezone can be set by applying a Tag to the resource
+        /// </summary>
+        public void GetTimeZoneFromTag()
+        {
+            string TEST_TIMEZONE_ID = "Mountain Standard Time";
+
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            // Add the tag in to state the timezone that should be used
+            resourceTags.Add("TIMEZONE", TEST_TIMEZONE_ID);
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                DateTime.UtcNow,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            powerSchedule.SetTimeZone();
+
+            // ensure that the zoneInfo is correctly set
+            TimeZoneInfo zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(TEST_TIMEZONE_ID);
+            Assert.Equal(zoneInfo, powerSchedule.zoneInfo);
+        }
+
+        [Fact]
+        public void ResourcePermittedToRunGMT() 
+        {
+            // set the time and the timezone to work with
+            DateTime timeReference = new DateTime(2021, 07, 02); 
+
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                timeReference,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            // ensure that the resource should be running now
+            powerSchedule.SetTimeZone();
+            powerSchedule.PermittedToRunDay();
+
+            Assert.True(powerSchedule.PermittedToRunOnDay);
+        }
+
+        [Fact]
+        public void ResourceNotPermittedToRunGMT() 
+        {
+            // set the time and the timezone to work with
+            DateTime timeReference = new DateTime(2021, 07, 03); 
+
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                timeReference,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            // ensure that the resource should be running Now
+            powerSchedule.SetTimeZone();
+            powerSchedule.PermittedToRunDay();
+
+            Assert.False(powerSchedule.PermittedToRunOnDay);
+        }        
+
+        [Fact]
+        public void ResourcePermittedToRunMountainTime()
+        {
+            string TEST_TIMEZONE_ID = "Mountain Standard Time";
+
+            // set the time and the timezone to work with
+            DateTime timeReference = new DateTime(2021, 07, 03, 0, 1, 0); 
+
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            // Add the tag in to state the timezone that should be used
+            resourceTags.Add("TIMEZONE", TEST_TIMEZONE_ID);
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                timeReference,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            // ensure that the resource should be running now
+            powerSchedule.SetTimeZone();
+            powerSchedule.PermittedToRunDay();
+
+            Assert.True(powerSchedule.PermittedToRunOnDay);            
+        }
+
+        [Fact]
+        public void ResourceShouldBeStopped()
+        {
+            // set the time and the timezone to work with
+            DateTime timeReference = new DateTime(2021, 07, 02, 21, 0, 0); 
+
+            // create the tags for the resource group and the 
+            Dictionary<string, string> groupTags = new Dictionary<string, string>();
+            Dictionary<string, string> resourceTags = new Dictionary<string, string>();
+
+            PowerSchedule powerSchedule = new PowerSchedule(
+                data.settings,
+                data.timeZones,
+                data.logger,
+                timeReference,
+                groupTags,
+                resourceTags,
+                POWER_STATE,
+                REGION
+            );
+
+            // ensure that the resource should be running now
+            powerSchedule.SetTimeZone();
+            powerSchedule.PermittedToRunDay();
+            powerSchedule.ShouldBeRunning();
+
+            Assert.True(powerSchedule.StopResource());
+        }
+    }
+}

--- a/tests/PowerScheduleTests.cs
+++ b/tests/PowerScheduleTests.cs
@@ -159,7 +159,8 @@ namespace Tests
             powerSchedule.SetTimeZone();
 
             // ensure that the zoneInfo is correctly set
-            TimeZoneInfo zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(TIMEZONE);
+            // TimeZoneInfo zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(TIMEZONE);
+            TimeZoneInfo zoneInfo = TimeZoneConverter.TZConvert.GetTimeZoneInfo(TIMEZONE);
             Assert.Equal(zoneInfo, powerSchedule.zoneInfo);
         }
 
@@ -192,7 +193,8 @@ namespace Tests
             powerSchedule.SetTimeZone();
 
             // ensure that the zoneInfo is correctly set
-            TimeZoneInfo zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(TEST_TIMEZONE_ID);
+            // TimeZoneInfo zoneInfo = TimeZoneInfo.FindSystemTimeZoneById(TEST_TIMEZONE_ID);
+            TimeZoneInfo zoneInfo = TimeZoneConverter.TZConvert.GetTimeZoneInfo(TEST_TIMEZONE_ID);
             Assert.Equal(zoneInfo, powerSchedule.zoneInfo);
         }
 

--- a/tests/TestsFixture.cs
+++ b/tests/TestsFixture.cs
@@ -3,7 +3,7 @@ using Azure.Reaper.Lib.Interfaces;
 using Azure.Reaper.Lib.Models;
 using System;
 using System.Collections.Generic;
-using Xunit;
+// using Xunit;
 
 public class TestsFixture : IDisposable
 {

--- a/tests/TestsFixture.cs
+++ b/tests/TestsFixture.cs
@@ -1,0 +1,82 @@
+
+using Azure.Reaper.Lib.Interfaces;
+using Azure.Reaper.Lib.Models;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+public class TestsFixture : IDisposable
+{
+
+    public List<Setting> settings;
+    public List<LocationTZ> timeZones;
+    public ILog logger;
+
+    // Global initialisation
+    public TestsFixture()
+    {
+        // Create a new logger for the tests
+        logger = new Azure.Reaper.Lib.Loggers.AppSerilog();
+
+        // configure settings for the tests
+        // these are to emulate the data that is retrieved from the database when running as a function
+        settings = new List<Setting>();
+
+        // add in the necessary settings for the tests
+        // -- start stop tag
+        Setting setting1 = new Setting();
+        setting1.name = "tag_vm_start_stop_time";
+        setting1.value = "STARTSTOPTIME";
+        settings.Add(setting1);
+
+        // -- name of the tag for setting the timezone
+        Setting setting2 = new Setting();
+        setting2.name = "tag_timezone";
+        setting2.value = "TIMEZONE";
+        settings.Add(setting2);
+
+        // -- set the days that resources are permitted to run on
+        Setting setting3 = new Setting();
+        setting3.name = "permitted_days";
+        setting3.value = "1,2,3,4,5";
+        settings.Add(setting3);
+        
+        // -- add the tag that holds the days of the week the resource is
+        // allowed to run on
+        Setting setting4 = new Setting();
+        setting4.name = "tag_days_of_week";
+        setting4.value = "DAYSOFWEEK";
+        settings.Add(setting4);
+
+        // -- add the settings for the start and stop times of resources
+        Setting setting5 = new Setting();
+        setting5.name = "vm_start";
+        setting5.value = "0800";
+        settings.Add(setting5);
+
+        Setting setting6 = new Setting();
+        setting6.name = "vm_stop";
+        setting6.value = "1800";
+        settings.Add(setting6);
+
+        // configure necessary timezones
+        timeZones = new List<LocationTZ>();
+
+        LocationTZ tz1 = new LocationTZ();
+        tz1.name = "ukwest";
+        tz1.tzId = "GMT Standard Time";
+        timeZones.Add(tz1);
+
+        LocationTZ tz2 = new LocationTZ();
+        tz2.name = "westcentralus";
+        tz2.tzId = "Mountain Standard Time";
+        timeZones.Add(tz2);
+
+    }
+
+    // Global teardown
+    public void Dispose()
+    {
+
+    }
+}


### PR DESCRIPTION
Added ability for Reaper to handle the startup and shutdown of Kubernetes clusters. This will only work for clusters that are set to use ScaleSets rather than AvailabilitySets - this is controlled by Azure.

The Cluster API is used to perform any shutdowns so the control plane is shutdown as well. The virtual machines are not directly managed. Indeed Azure Reaper will not attempt to iterate over machines that are in a "MC_" (managed cluster) resource group.

The power schedule for devices has been moved into a new class. New tests have been added to this and the build has been updated.